### PR TITLE
:cuda() to return self

### DIFF
--- a/utils/AdaptiveLoss.lua
+++ b/utils/AdaptiveLoss.lua
@@ -60,4 +60,5 @@ function AdaptiveLoss:cuda()
    for i = 1, #self.criterions do
       self.criterions[i]:cuda()
    end
+   return self
 end

--- a/utils/AdaptiveLoss.lua
+++ b/utils/AdaptiveLoss.lua
@@ -26,7 +26,7 @@ function AdaptiveLoss:remapTarget(target)
       if m:any() then
          table.insert(new_target, target[m]:add(-cutoff[i]))
       else
-         table.insert(new_target, false)
+         table.insert(new_target, {})
       end
    end
    return new_target
@@ -40,7 +40,7 @@ function AdaptiveLoss:updateOutput(input, target)
    self.gradInput = {}
 
    for i = 1, #input do
-      if input[i] then
+      if torch.isTensor(input[i]) then
          assert(target[i]:min() > 0 and target[i]:max() <= input[i]:size(2))
          local criterion = self.criterions[i]
          self.output = self.output + criterion:updateOutput(input[i], target[i])

--- a/utils/AdaptiveSoftMax.lua
+++ b/utils/AdaptiveSoftMax.lua
@@ -46,7 +46,7 @@ function AdaptiveSoftMax:setTarget(target)
          -- the nonzero function is not implemented for CudaTensor :(
          table.insert(self.idx, m:float():nonzero():squeeze(2))
       else
-         table.insert(self.idx, false)
+         table.insert(self.idx, {})
       end
    end
 end
@@ -58,11 +58,11 @@ function AdaptiveSoftMax:updateOutput(input)
    table.insert(self.output, self.head.output)
 
    for i = 1, #self.idx do
-      if self.idx[i] then
+      if torch.isTensor(self.idx[i]) then
          self.tail[i]:updateOutput(input:index(1, self.idx[i]))
          table.insert(self.output, self.tail[i].output)
       else
-         table.insert(self.output, false)
+         table.insert(self.output, {})
       end
    end
 
@@ -76,7 +76,7 @@ function AdaptiveSoftMax:updateGradInput(input, gradOutput)
    self.gradInput:copy(self.head.gradInput)
 
    for i = 1, #self.idx do
-      if self.idx[i] then
+      if torch.isTensor(self.idx[i]) then
          self.tail[i]:updateGradInput(input:index(1, self.idx[i]), gradOutput[i+1])
          self.gradInput:indexAdd(1, self.idx[i], self.tail[i].gradInput)
       end
@@ -89,7 +89,7 @@ function AdaptiveSoftMax:accGradParameters(input, gradOutput)
    self.head:accGradParameters(input, gradOutput[1])
 
    for i = 1, #self.idx do
-      if self.idx[i] then
+      if torch.isTensor(self.idx[i]) then
          self.tail[i]:accGradParameters(input:index(1, self.idx[i]), gradOutput[i+1])
       end
    end


### PR DESCRIPTION
Hello! thanks for sharing this excellent work! 

just a small fix on `cuda()` operator which is supposed to return self, and I also changed `false` to `{}` in the output of `AdaptiveSoftmax` so that we can use `AdaptiveLoss` in a `nn.ParallelCriterion` (which expects input to be table of tensor/table). 